### PR TITLE
add logging about incoming requests with middleware

### DIFF
--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ func main() {
 	mux := http.NewServeMux()
 	finalHandler := http.HandlerFunc(handler.RunHandler)
 	mux.Handle("/run", logger(finalHandler))
+	mux.Handle("/", logger(http.NotFoundHandler()))
 
 	log.Println("Starting server on localhost:8000")
 	err := http.ListenAndServe(":8000", mux)

--- a/main.go
+++ b/main.go
@@ -2,15 +2,35 @@ package main
 
 import (
 	"github.com/wwgberlin/repl2go/handler"
-	"fmt"
 	"log"
 	"net/http"
+	"time"
 )
 
+// logging middleware that logs the incoming requests
+func logger(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		// log request
+		log.Printf("%s %s on %s%s\n", r.Proto, r.Method, r.Host, r.URL)
+
+		// hand over to next handler
+		next.ServeHTTP(w, r)
+
+		// log response
+		end := time.Now()
+		duration := end.Sub(start)
+		log.Printf("done in %fs!", duration.Seconds())
+	})
+}
+
 func main() {
-	http.HandleFunc("/run", handler.RunHandler)
-	fmt.Println("Starting server")
-	err := http.ListenAndServe(":8000", nil)
+	mux := http.NewServeMux()
+	finalHandler := http.HandlerFunc(handler.RunHandler)
+	mux.Handle("/run", logger(finalHandler))
+
+	log.Println("Starting server on localhost:8000")
+	err := http.ListenAndServe(":8000", mux)
 	if err != nil {
 		log.Fatal("ListenAndServe: ", err)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -1,2 +1,27 @@
 package main_test
 
+import (	
+	"net/http"	
+	"net/http/httptest"	
+	"testing"
+	"github.com/wwgberlin/repl2go/handler"
+)
+
+func TestRunMainNotFound(t *testing.T) {
+	req, err := http.NewRequest("GET", "/doesnotexist", nil)
+	if err != nil {	
+		t.Fatal(err)	
+	}	
+			
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(handler.RunHandler)	
+
+	// Our handlers satisfy http.Handler, so we can call their ServeHTTP method	
+	// directly and pass in our Request and ResponseRecorder.	
+	handler.ServeHTTP(rr, req)	
+
+	// Check the status code is what we expect.	
+	if status := rr.Code; status != http.StatusNotFound {		
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusNotFound);
+	}
+}


### PR DESCRIPTION
This PR adds some simple logging to our HTTP Server
- use (log)[https://golang.org/pkg/log] instead of fmt for any output
- create a Middleware for logging and use it on `/run` as well as on `/` (with a `http.NotFoundHandler`)
- to make sure the changes did not break main, I added a very basic test for a 404 route (based on existing tests)

**What is logged?**
- add the Port to the log on server start
- log incoming requests with timestamp, Method and Route: `2020/10/31 17:10:18 HTTP/1.1 GET on localhost:8000/run`
- log after response with duration: `2020/10/31 17:10:18 done in 0.000050s!`

Not sure if it covers the whole scope of https://trello.com/c/57r0bhwF/19-add-logging-package
I did not add a logging library outside the standard lib's log package. I did some research and I think this makes more sense after we have a better understanding of the infrastructure we will have.

**What else could be added /improved**
- log to a file instead of stdout (or in addition?)
- adding more detailed logging inside the run handler
- write a proper test for the logger somehow (either check if the logger function was called or check stdout somehow?)